### PR TITLE
Bug fix when source or target custom field values are added or deleted

### DIFF
--- a/LinkedCustomFields/LinkedCustomFields.API.php
+++ b/LinkedCustomFields/LinkedCustomFields.API.php
@@ -50,7 +50,7 @@ class LinkedCustomFieldsDao {
     static function getLinkedValuesMap( $p_source_field_id ) {
         
         $t_query = "SELECT custom_field_value, target_field_values FROM " . plugin_table('data') . 
-                    " WHERE custom_field_id=".db_param() ." ORDER BY custom_field_value_order" ;
+                    " WHERE custom_field_id=".db_param() ." ORDER BY custom_field_value" ;
         $t_result = db_query_bound( $t_query, array ( $p_source_field_id ) );
         if ( 0 == db_num_rows ( $t_result ) ) {
             return array();
@@ -63,7 +63,7 @@ class LinkedCustomFieldsDao {
             $t_source_value = $t_array['custom_field_value'];
             $t_target_values_imploded = $t_array['target_field_values'];
             
-            $t_return[] = array($t_source_value, explode( '|', $t_target_values_imploded ));
+            $t_return[$t_source_value] = explode( '|', $t_target_values_imploded );
         }
         
         return $t_return;

--- a/LinkedCustomFields/LinkedCustomFields.php
+++ b/LinkedCustomFields/LinkedCustomFields.php
@@ -21,7 +21,7 @@ class LinkedCustomFieldsPlugin extends MantisPlugin {
         $this->name = plugin_lang_get("title");
         $this->description = plugin_lang_get("description");
 
-        $this->version = "1.0";
+        $this->version = "2.0";
         $this->requires = array(
 			"MantisCore" => "1.2.6",
 			"jQuery" => "1.8"

--- a/LinkedCustomFields/pages/bug_page_custom_field_links.php
+++ b/LinkedCustomFields/pages/bug_page_custom_field_links.php
@@ -54,9 +54,8 @@ foreach ( $t_all_custom_field_ids as $t_custom_field_id ) {
         echo 'allFieldValues["' .$t_custom_field_id.'"] = ' . JavascriptUtils::toJSArray( explode('|', $t_linked_field['possible_values']) ).";\n";
         echo 'linkedFieldValues["'.$t_custom_field_id."\"] = {};\n";
         
-        foreach ( $t_linked_values as $t_linked_value_arr ) {
-            list($t_source_value, $t_target_values ) = $t_linked_value_arr;
-            echo 'linkedFieldValues["'.$t_custom_field_id.'"]["'. $t_source_value.'"] = ' . JavascriptUtils::toJSArray( $t_target_values ).";\n";
+        foreach ( $t_linked_values as $t_idx => $t_values ) {
+            echo 'linkedFieldValues["'.$t_custom_field_id.'"]["'. $t_idx .'"] = ' . JavascriptUtils::toJSArray( $t_values ).";\n";
         }
     }
 }

--- a/LinkedCustomFields/pages/configure_custom_field_link.php
+++ b/LinkedCustomFields/pages/configure_custom_field_link.php
@@ -82,10 +82,14 @@
         </tr>
     </thead>
     <tbody>
-        <?php foreach ( explode('|', $f_custom_field['possible_values'] ) as $t_idx =>  $t_possible_value ) { ?>
+        <?php 
+        	$t_sorted_possible_values = explode('|', $f_custom_field['possible_values'] );
+        	sort($t_sorted_possible_values);
+        	foreach ( $t_sorted_possible_values as $t_idx =>  $t_possible_value ) { 
+		?>
             <tr <?php echo helper_alternate_class() ?>>
                 <td> <?php echo $t_possible_value ?></td>
-                <td><select id="custom_field_linked_values_<?php echo $t_idx?>" name="custom_field_linked_values_<?php echo $t_idx?>[]" multiple="multiple"></select></td>
+                <td><select id="custom_field_linked_values_<?php echo str_replace(' ', '-', $t_possible_value)?>" name="custom_field_linked_values_<?php echo str_replace(' ', '-', $t_possible_value)?>[]" multiple="multiple" size="8"></select></td>
             </tr>
         <?php } ?>
             <tr>
@@ -103,7 +107,6 @@
 var targetValues = {};
 <?php 
     foreach ( $t_target_candidates as $t_target_candidate ) {
-        
         $t_field_values_js = JavascriptUtils::toJSArray( explode( '|', $t_target_candidate['possible_values'] ) );
         echo 'targetValues["' . $t_target_candidate['id'] .'"] = '.$t_field_values_js." ;\n";
     }
@@ -113,11 +116,9 @@ var refreshTargetFieldOptions = function(targetFieldId) {
     var sourceValues = targetValues[jQuery("#custom_field_id").val()];
     var targetDisplayValues = targetValues[targetFieldId];
 
-    var i = 0 ;
     for ( field in sourceValues ) {
 	    var sourceValue = sourceValues[field];
-	    var control = jQuery('#custom_field_linked_values_' + i);
-	    i++;
+	    var control = jQuery('#custom_field_linked_values_' + sourceValue.replace(" ", "-"));
 	    
 	    control.empty();
 	    for ( field in targetDisplayValues ) {
@@ -139,10 +140,7 @@ jQuery(document).ready(function() {
     <?php 
         $t_existing_values = LinkedCustomFieldsDao::getLinkedValuesMap( $f_custom_field['id'] );
         foreach ( $t_existing_values as $t_idx => $t_values ) {
-
-            list( $t_key, $t_value) = $t_values;
-            echo 'jQuery("#custom_field_linked_values_'.$t_idx.'").val('. JavascriptUtils::toJSArray( $t_value ). ')'."\n";
-            $t_idx++;
+            echo 'jQuery("#custom_field_linked_values_'.str_replace(' ', '-', $t_idx).'").val('. JavascriptUtils::toJSArray( $t_values ). ')'."\n";
         }
     ?>
 });

--- a/LinkedCustomFields/pages/configure_custom_field_link_update.php
+++ b/LinkedCustomFields/pages/configure_custom_field_link_update.php
@@ -26,6 +26,10 @@
 	$f_source_field_id =  gpc_get_int('custom_field_id');
 	$t_source_field = custom_field_get_definition( $f_source_field_id );
 	$t_source_field_values = explode ( '|', $t_source_field['possible_values']);
+	$t_adapted_source_field_values = array();
+	foreach ($t_source_field_values as $value) {
+		$t_adapted_source_field_values[str_replace(' ', '-', $value)] = $value;
+	}
 	
 	$f_target_field_id = gpc_get_int('target_custom_field');
 	
@@ -34,7 +38,7 @@
 	    if ( strpos($f_post_key, 'custom_field_linked_values_') === 0 ) {
 	        
 	        $t_source_value_index = substr( $f_post_key, strlen ('custom_field_linked_values_') );
-	        $t_source_value = $t_source_field_values[ $t_source_value_index ];
+	        $t_source_value = $t_adapted_source_field_values[ $t_source_value_index ];
 	        $t_linked_value = gpc_get( $f_post_key );
             $t_value_mappings[$t_source_value] = $t_linked_value;
 	    }


### PR DESCRIPTION
Modify the array’s index build so that it is now possible to add custom
values wherever you want in your source and target custom fields
without loosing all your previous registered links.
The array’s indexes are now build with the values themselves and no
longer the array’index number  which was causing wrong links when
custom fields values were added or deleted.
